### PR TITLE
Add email notifications and comments to data requests

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,23 @@ Installation
 
 - pip install -r requirements.txt
 
-- Add 'data_requests' and 'django_tables2' to your INSTALLED_APPS setting
+- Add the following to your INSTALLED_APPS setting::
+
+    INSTALLED_APPS = (
+                    ...
+                    'data_requests',
+                    'django_tables2',
+
+- Add the following to settings.py to enable email notifications::
+
+    DATA_REQUEST_NOTIFY = True
+    DATA_REQUEST_EMAILS = [<email_address>,]
+    DEFAULT_EMAIL_FROM = <default_from_email>
+    EMAIL_USE_TLS = False
+    EMAIL_HOST = <your_email_host>
+    EMAIL_HOST_USER = <email_host_user>
+    EMAIL_HOST_PASSWORD = <email_host_password>
+    EMAIL_PORT = <email_host_port>
 
 - Add the data_requests urls to your project's urls.py file::
 

--- a/data_requests/admin.py
+++ b/data_requests/admin.py
@@ -1,0 +1,13 @@
+from django.contrib import admin
+
+from geonode.base.admin import MediaTranslationAdmin, ResourceBaseAdminForm
+from data_requests.models import DataRequest
+
+
+class DataRequestAdmin(admin.ModelAdmin):
+    model = DataRequest
+    list_display_links = ('name',)
+    list_display = ('id', 'name', 'description', 'url', 'data_url')
+    search_fields = ('name', 'url', 'data_url')
+
+admin.site.register(DataRequest, DataRequestAdmin)

--- a/data_requests/models.py
+++ b/data_requests/models.py
@@ -2,6 +2,8 @@ from django.db import models
 from django.utils.translation import ugettext_lazy as _
 from django_tables2 import tables
 from django_tables2.utils import A
+from django.conf import settings
+from django.core.urlresolvers import reverse
 
 __author__ = 'mbertrand'
 
@@ -12,6 +14,9 @@ DATA_STATUS_CHOICES = (
         ('Duplicate', 'Duplicate'),
         ('Rejected', 'Rejected'),
 )
+
+DATA_REQUEST_NOTIFY = getattr(settings, 'DATA_REQUEST_NOTIFY', False)
+DATA_REQUEST_EMAILS = getattr(settings, 'DATA_REQUEST_EMAILS', settings.ADMINS)
 
 
 class DataRequest(models.Model):
@@ -39,6 +44,8 @@ class DataRequest(models.Model):
     created_dttm = models.DateTimeField(auto_now_add=True)
     modified_dttm = models.DateTimeField(auto_now=True)
 
+    def get_absolute_url(self):
+        return reverse('data_request_detail', args=(self.id,))
 
 class DataRequestTable(tables.Table):
     """

--- a/data_requests/templates/data_requests/email.txt
+++ b/data_requests/templates/data_requests/email.txt
@@ -1,0 +1,36 @@
+{% load i18n %}
+{% trans "The following data request has been updated:" %}
+
+{{ data_request.name }} - {{ data_request_url }}
+
+{% if data_request.created_dttm %}
+{% trans "Created" %}: {{ data_request.created_dttm|date:"M d, Y H:i"}}
+{% endif %}
+{% if data_request.status %}
+{% trans "Status" %}: {{ data_request.status|escape|safe}}
+{% endif %}
+{% if data_request.requestor_name %}
+{% trans "Requestor" %}: {{ data_request.requestor_name }}
+{% endif %}
+{% if data_request.source %}
+{% trans "Source" %}: {{ data_request.source|escape|safe }}
+{% endif %}
+{% if data_request.description %}
+{% trans "Description" %}: {{ data_request.description|escape|safe}}
+{% endif %}
+{% if data_request.url %}
+{% trans "URL" %}: {{ data_request.url|escape|safe }}
+{% endif %}
+{% if data_request.data_url %}
+{% trans "Imported Data URL" %}: {{ data_request.data_url|escape|safe}}
+{% endif %}
+{% if data_request.data_license_url %}
+{% trans "Data License URL" %}: {{ data_request.data_license_url|escape|safe}}
+{% endif %}
+{% if data_request.metadata_url %}
+{% trans "Metadata License URL" %}: {{ data_request.metadata_url|escape|safe}}
+{% endif %}
+{% if data_request.modified_dttm %}
+{% trans "Modified" %}: {{ data_request.modified_dttm|date:"M d, Y H:i"}}
+{% endif %}
+

--- a/data_requests/templates/data_requests/request_detail.html
+++ b/data_requests/templates/data_requests/request_detail.html
@@ -3,7 +3,7 @@
 {% load bootstrap_tags %}
 {% load url from future %}
 {% load base_tags %}
-
+{% load dialogos_tags %}
 {% block title %}{% endblock %}
 
 {% block body_outer %}
@@ -74,7 +74,43 @@
 </article>
 
 {% if request.user.is_superuser or request.user.email == object.requestor_email %}
-   <a href="{%  url "data_request_edit" object.id %}">{%  trans "Update this request" %}</a>
+   <a href="{%  url "data_request_edit" object.pk %}">{%  trans "Update this request" %}</a>
 {% endif %}
 
+
+{% with object as resource %}
+  {% include "_comments.html" %}
+{% endwith %}
+
 {% endblock %}
+
+{% block extra_script %}
+    <script type="text/javascript">
+       $("#comment_submit_btn").click(function(event) {
+            $.ajax({
+              type: "POST",
+              url: $("#form_post_comment").attr('action'),
+              data: $("#form_post_comment").serialize(),
+              success: function() {
+                $('#form_post_comment_div').modal('hide');
+                $('#comments_section').load(window.location.pathname + ' #comments_section',
+                		function(){$(this).children().unwrap()})
+              }
+            });
+            return false;
+          });
+       $(".btn btn-danger btn-xs").click(function(event) {
+            $.ajax({
+              type: "POST",
+              url: $("#form_post_comment").attr('action'),
+              data: $("#form_post_comment").serialize(),
+              success: function() {
+                $('#form_post_comment_div').modal('hide');
+                $('#comments_section').load(window.location.pathname + ' #comments_section',
+                		function(){$(this).children().unwrap()})
+              }
+            });
+            return false;
+          });
+    </script>
+{% endblock extra_script %}

--- a/data_requests/urls.py
+++ b/data_requests/urls.py
@@ -15,5 +15,4 @@ urlpatterns = [
         template_name='data_requests/request_detail.html'),
         name='data_request_detail'),
     url(r'^new$', views.request_new, name='data_request_new'),
-
 ]

--- a/data_requests/views.py
+++ b/data_requests/views.py
@@ -1,16 +1,24 @@
+import django_filters
+from django.utils.translation import ugettext_lazy as _
 from django.contrib.auth.decorators import login_required
 from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect
 from django.shortcuts import render_to_response
 from django.template import RequestContext
 from django.template.response import TemplateResponse
+from django.template.loader import render_to_string
 from django.views.generic import DetailView
 from django_tables2 import SingleTableView
-import django_filters
-from .models import DataRequest, DataRequestTable
-from .forms import DataRequestForm, DataRequestAdminForm
+from django.conf import settings
+from django.core.urlresolvers import reverse
+from django.core.mail import send_mail
+from urlparse import urljoin
+from data_requests.models import DataRequest, DataRequestTable
+from data_requests.forms import DataRequestForm, DataRequestAdminForm
+
 
 DEFAULT_LIST_PARAMS = "?status=Open&sort=-modified_dttm"
+
 
 def request_new(request, template='data_requests/request_new.html'):
     """
@@ -20,7 +28,9 @@ def request_new(request, template='data_requests/request_new.html'):
         # save new request
         form = DataRequestForm(request.POST)
         if form.is_valid():
-            form.save()
+            data_request = form.save()
+            if settings.DATA_REQUEST_NOTIFY:
+                notify(data_request, request.user)
             return HttpResponseRedirect(reverse('data_request_list') +
                                         DEFAULT_LIST_PARAMS)
     else:
@@ -51,6 +61,8 @@ def request_edit(request, request_id,
         form = DataRequestAdminForm(request.POST, instance=data_request)
         if form.is_valid():
             form.save()
+            if settings.DATA_REQUEST_NOTIFY:
+                notify(data_request, request.user)
             return HttpResponseRedirect(reverse('data_request_list') +
                                         DEFAULT_LIST_PARAMS)
     else:
@@ -59,6 +71,28 @@ def request_edit(request, request_id,
         "request_form": form,
         "data_request": data_request
     }))
+
+
+def notify(data_request, user):
+    """
+    Send email notifications about a new/updated datarequest
+    """
+    req_url = urljoin(settings.SITEURL,
+              reverse('data_request_detail', args=(data_request.id,)))
+    msg_plain = render_to_string('data_requests/email.txt',
+                                 {
+                                     'data_request': data_request,
+                                     'data_request_url': req_url
+                                 })
+    if user.is_anonymous() or user.email == data_request.requestor_email:
+        sender = data_request.requestor_email
+        recipients = settings.DATA_REQUEST_EMAILS
+    else:
+        sender = settings.DEFAULT_FROM_EMAIL
+        recipients = (data_request.requestor_email,)
+    send_mail(_('Data request update - {}'.format(data_request.name)),
+              msg_plain, sender,
+              recipients, fail_silently=True)
 
 
 class DataRequestDetailView(DetailView):

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     packages=['data_requests', ],
     install_requires=[
       'django-tables2==1.0.4',
-      'django-filter==0.11'
+      'django-filter==0.11',
     ],
     include_package_data=True,
     zip_safe=False,


### PR DESCRIPTION
Whenever a data request is created, updated, or modified, an email will be sent to either the data requestor (if the update was made by anyone else) or the emails specified in django's settings.DATA_REQUEST_EMAILS, showing the current state of the request.
Example:

``````
Subject: Data request update - NASA STRM data
The following data request has been updated:

NASA SRTM data - http://localhost:8000/datarequests/detail/38/

Created: Jan 11, 2016 11:05
Status: Open
Requestor: Matt Bertrand
Source: http://www2.jpl.nasa.gov/srtm/
Description: Data from the NASA SRTM mission
URL: http://earthexplorer.usgs.gov/
Imported Data URL: http://localhost:8000/layers/geonode%3Asrtm4326```
``````

The comments system already in place in GeoNode for layers, maps, etc has been extended to data requests - users must be logged in to post comments.
![screen shot 2016-01-11 at 11 06 38 am](https://cloud.githubusercontent.com/assets/187676/12238827/daf43d64-b853-11e5-8a46-d2a604999801.png)
![screen shot 2016-01-11 at 11 06 47 am](https://cloud.githubusercontent.com/assets/187676/12238826/daf11d6e-b853-11e5-8628-3ed307187146.png)
